### PR TITLE
Amended Trafford pilot summary

### DIFF
--- a/pilots.html
+++ b/pilots.html
@@ -34,10 +34,8 @@
 <section>
 <h2>Project Pilots</h2>
 
-<h3> Trafford pilot </h3>
-	<p>
-This pilot focusses on the worklessness. Trafford innovation lab cooperated closely with Swirrl, who are handling the more technical aspects of modelling and storing the linked data. The goal is to build a tool that will bring together data from a range of sources to help understand the factors that contribute to, or are impacted by, worklessness. Unemployed, representatives from the Department for Work and Pensions; Trafford’s Economic Growth Team and the Greater Manchester Combined Authority are involved in the co-creation. This should result in less unemployment ad better use of spending on the worklessness.
-	<p>
+<h3> Trafford Worklessness Pilot </h3>
+    <p>The Trafford Worklessness Pilot produced a suite of applications that visualised linked open statistical data, and other open data sources, to identify areas of need and inform service delivery relating to worklessness. These applications were developed by the Trafford Data Lab in a co-creative effort with work coaches from the Jobcentre Plus in Stretford and council leads for worklessness from across Greater Manchester. Swirrl, the pilot's technical partner, modelled and stored the linked data.</p>
 	Links:
 	<ul>
 	<li><a href='http://www.trafforddatalab.io/opengovintelligence/'>Linked Open Statistical Data (LOSD) driven Public Services of Trafford Council at Manchester, the UK</a>    


### PR DESCRIPTION
Updated the wording of the Trafford Pilot summary to emphasise the involvement of the Jobcentre Plus team and correct the name of the Lab.